### PR TITLE
Make tests insensitive to hashing (Julia 1.13 compat)

### DIFF
--- a/src/record.jl
+++ b/src/record.jl
@@ -501,6 +501,8 @@ end
     infokeys(record::Record)::Vector{String}
 Get the keys of the additional information of `record`.
 This function returns an empty vector when the INFO field is missing.
+
+The order of keys are an implementation detail and may change in future versions.
 """
 function infokeys(record::Record)::Vector{String}
     checkfilled(record)

--- a/test/vcf.jl
+++ b/test/vcf.jl
@@ -94,7 +94,7 @@
     @test VCF.info(record, "AA") == "AT"
     @test VCF.hasinfo(record, "DB")
     @test VCF.info(record, "DB") == ""
-    @test VCF.infokeys(record) == ["DP", "AA", "DB"]
+    @test Set(VCF.infokeys(record)) == Set(["DP", "AA", "DB"])
     @test !VCF.hasinfo(record, "XY")
     record = VCF.Record(record, genotype=[Dict("GT" => "0/0", "DP" => [10,20])])
     @test VCF.format(record) == ["DP", "GT"]


### PR DESCRIPTION
One test accidentally relied on Base hashing, and specifically the order of keys in a Dict. This is subject to change across minor Julia versions.

This fixes tests suite for Julia 1.13, see the failure in https://github.com/JuliaLang/julia/pull/59753 