### PR TITLE
Use OrderedDict instead of Dict in unit tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,9 @@ BufferedStreams = "1"
 julia = "1.6"
 
 [extras]
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [targets]
-test = ["Test", "YAML"]
+test = ["Test", "YAML", "OrderedCollections"]

--- a/test/bcf.jl
+++ b/test/bcf.jl
@@ -31,7 +31,7 @@ end
     @test BCF.alt(record) == ["ATT", "ACT"]
     record = BCF.Record(record, filter = [2, 3])
     @test BCF.filter(record) == [2, 3]
-    record = BCF.Record(record, info=Dict(1 => Int8[42]))
+    record = BCF.Record(record, info=OrderedDict(1 => Int8[42]))
     @test BCF.info(record) == [(1, 42)]
     @test BCF.info(record, simplify=false) == [(1, [42])]
     @test BCF.info(record, 1) == 42

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using VariantCallFormat
 import BufferedStreams: BufferedInputStream
 import YAML
 
+using OrderedCollections: OrderedDict
+
 include("vcf.jl")
 include("bcf.jl")
 

--- a/test/vcf.jl
+++ b/test/vcf.jl
@@ -87,7 +87,7 @@
     @test VCF.qual(record) == 11.2
     record = VCF.Record(record, filter="PASS")
     @test VCF.filter(record) == ["PASS"]
-    record = VCF.Record(record, info=Dict("DP" => 20, "AA" => "AT", "DB"=>nothing))
+    record = VCF.Record(record, info=OrderedDict("DP" => 20, "AA" => "AT", "DB"=>nothing))
     @test VCF.hasinfo(record, "DP")
     @test VCF.info(record, "DP") == "20"
     @test VCF.hasinfo(record, "AA")
@@ -96,7 +96,7 @@
     @test VCF.info(record, "DB") == ""
     @test VCF.infokeys(record) == ["DP", "AA", "DB"]
     @test !VCF.hasinfo(record, "XY")
-    record = VCF.Record(record, genotype=[Dict("GT" => "0/0", "DP" => [10,20])])
+    record = VCF.Record(record, genotype=[OrderedDict("GT" => "0/0", "DP" => [10,20])])
     @test VCF.format(record) == ["DP", "GT"]
     @test VCF.genotype(record) == [["10,20", "0/0"]]
 


### PR DESCRIPTION
Use `OrderedDict` instead of `Dict` in unit tests to be able to test order in e.g. `infokeys`.
Alternative solution to #18.